### PR TITLE
EM- Added consistant envelopes

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from distutils.core import setup
 
 setup(name='Thorium',
-      version='0.1.17',
+      version='0.1.18',
       description='A Python framework for simple RESTful API interfaces',
       author='Ryan Easterbrook',
       author_email='ryan@eventmobi.com',

--- a/thorium/errors.py
+++ b/thorium/errors.py
@@ -11,8 +11,8 @@ class HttpErrorBase(Exception):
     status_code = None
     default_message = None
 
-    def __init__(self, message=None, headers={}):
-        self.headers = headers
+    def __init__(self, message=None, headers=None):
+        self.headers = headers if headers else {}
         super().__init__(message or self.default_message)
 
 

--- a/thorium/exception_handler.py
+++ b/thorium/exception_handler.py
@@ -1,22 +1,26 @@
-import json
-from .errors import InternalSeverError
 import sys
+from .errors import InternalSeverError
+from .serializer import JsonSerializer
+from .response import ErrorResponse
 
 
 class ExceptionHandler(object):
 
     def __init__(self, logger):
         self.logger = logger
+        self.serializer = JsonSerializer()
 
-    def handle_general_exception(self, url, method, e):
+    def handle_general_exception(self, url, method, e, request):
         """
         Logs an exception then returns an InternalServerError http response body
         """
         self.logger.error('Exception on {0} [{1}]'.format(url, method), exc_info=sys.exc_info())
-        return self.handle_http_exception(InternalSeverError())
+        return self.handle_http_exception(InternalSeverError(), request)
 
-    def handle_http_exception(self, e):
+    def handle_http_exception(self, http_error, request):
         """
         Builds a response body for a http exception.
         """
-        return json.dumps({'error': str(e), 'status': e.status_code})
+        error_response = ErrorResponse(http_error, request)
+        serialized_response = self.serializer.serialize_response(error_response)
+        return serialized_response

--- a/thorium/routing.py
+++ b/thorium/routing.py
@@ -54,13 +54,19 @@ class RouteManager(object):
         and :class:`.Route`. Calls :func:`add_route` for the actual adding.
         """
         #register collection route
-        collection_dsp = dispatcher.CollectionDispatcher(resource_cls=resource_cls, engine_cls=engine_cls, allowed_methods=resource_cls.Meta.collection['methods'])
-        col_route = Route('{0}_{1}'.format(resource_cls.__name__, collection_dsp.request_type), resource_cls.Meta.collection['endpoint'], collection_dsp)
+        collection_dsp = dispatcher.CollectionDispatcher(resource_cls=resource_cls,
+                                                         engine_cls=engine_cls,
+                                                         allowed_methods=resource_cls.Meta.collection['methods'])
+        col_route = Route('{0}_{1}'.format(resource_cls.__name__, collection_dsp.request_type),
+                          resource_cls.Meta.collection['endpoint'], collection_dsp)
         self.add_route(col_route)
 
         #register detail route
-        detail_dsp = dispatcher.DetailDispatcher(resource_cls=resource_cls, engine_cls=engine_cls, allowed_methods=resource_cls.Meta.detail['methods'])
-        detail_route = Route('{0}_{1}'.format(resource_cls.__name__, detail_dsp.request_type), resource_cls.Meta.detail['endpoint'], detail_dsp)
+        detail_dsp = dispatcher.DetailDispatcher(resource_cls=resource_cls,
+                                                 engine_cls=engine_cls,
+                                                 allowed_methods=resource_cls.Meta.detail['methods'])
+        detail_route = Route('{0}_{1}'.format(resource_cls.__name__, detail_dsp.request_type),
+                             resource_cls.Meta.detail['endpoint'], detail_dsp)
         self.add_route(detail_route)
 
         return {'collection_route': col_route, 'detail_route': detail_route}

--- a/thorium/testsuite/test_thoriumflask.py
+++ b/thorium/testsuite/test_thoriumflask.py
@@ -71,7 +71,7 @@ class TestThoriumFlask(unittest.TestCase):
     def test_simple_detail_get(self):
         rv = self.c.open('/api/event/1/people/1', method='GET')
         self.assertEqual(rv.status_code, 200)
-        data = json.loads(rv.data.decode())
+        data = json.loads(rv.data.decode())['data']
         self.assertEqual(data['name'], 'Timmy')
         self.assertEqual(data['admin'], True)
         self.assertEqual(data['id'], 42)
@@ -80,8 +80,8 @@ class TestThoriumFlask(unittest.TestCase):
         rv = self.c.open('/api/event/1/people', method='GET')
         self.assertEqual(rv.status_code, 200)
         body = json.loads(rv.data.decode())
-        items = body['items']
-        meta = body['_meta']
+        items = body['data']
+        meta = body['meta']
         self.assertEqual(meta, {})
         self.assertIsInstance(items, list)
         self.assertEqual(len(items), 1)

--- a/thorium/thoriumflask.py
+++ b/thorium/thoriumflask.py
@@ -33,6 +33,7 @@ class FlaskEndpoint(object):
     @crossdomain(origin='*')
     def endpoint_target(self, **kwargs):
         url = method = 'unknown'
+        request = None
         try:
             request = self.build_request()
             url = request.url
@@ -41,12 +42,12 @@ class FlaskEndpoint(object):
             return FlaskResponse(response=serialized_body, headers=response.headers,
                                  status=response.status_code, content_type='application/json')
         except errors.HttpErrorBase as e:
-            error_body = self.exception_handler.handle_http_exception(e)
+            error_body = self.exception_handler.handle_http_exception(e, request)
             return FlaskResponse(response=error_body, status=e.status_code,
                                  headers=e.headers, content_type='application/json')
         except Exception as e:
             traceback.print_exc()
-            error_body = self.exception_handler.handle_general_exception(url, method, e)
+            error_body = self.exception_handler.handle_general_exception(url, method, e, request)
             if self.flask_config['DEBUG']:  # if flask debug raise exception instead of returning json response
                 raise e
             return FlaskResponse(response=error_body, status=500, headers={}, content_type='application/json')


### PR DESCRIPTION
#### What's this PR do?

Updates thorium with consistent envelopes for each type of request. Also includes some refactoring of the response module.
#### Where should the reviewer start?

The two most relevant files are response.py and serializer.py
#### Any background context you want to provide?

Collection responses were already returning in an envelope, however Detail and Error responses were not. This change adds an envelope for the two latter and updates the former to match.
#### What are the relevant tickets?

N/A

In branch: feature/consistant-response-envelopes
