### PR TITLE
EM- Thorium resource fields should now be serialized in the same order t...

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from distutils.core import setup
 
 setup(name='Thorium',
-      version='0.1.21',
+      version='0.1.22',
       description='A Python framework for simple RESTful API interfaces',
       author='Ryan Easterbrook',
       author_email='ryan@eventmobi.com',

--- a/thorium/response.py
+++ b/thorium/response.py
@@ -1,3 +1,6 @@
+from collections import OrderedDict
+
+
 class Response(object):
 
     def __init__(self, request):
@@ -40,7 +43,7 @@ class DetailResponse(Response):
     def get_response_data(self):
         data = None
         if self.resource:
-            data = {n: v.get() for n, v in self.resource.all_fields()}
+            data = OrderedDict(((n, v.get()) for n, v in self.resource.all_fields()))
         return data
 
 
@@ -55,7 +58,7 @@ class CollectionResponse(Response):
         data = []
         if self.resources:
             for res in self.resources:
-                data.append({n: v.get() for n, v in res.all_fields()})
+                data.append(OrderedDict(((n, v.get()) for n, v in res.all_fields())))
         return data
 
 

--- a/thorium/serializer.py
+++ b/thorium/serializer.py
@@ -1,4 +1,5 @@
 import json
+from collections import OrderedDict
 
 
 class SerializerBase(object):
@@ -14,7 +15,13 @@ class SerializerBase(object):
 
     @staticmethod
     def _build_envelope(response_type, status, error, data, meta):
-        return {'type': response_type, 'status': status, 'error': error, 'data': data, 'meta': meta}
+        envelope = OrderedDict()
+        envelope['type'] = response_type
+        envelope['status'] = status
+        envelope['error'] = error
+        envelope['data'] = data
+        envelope['meta'] = meta
+        return envelope
 
     def _serialize_data(self, data):
         raise NotImplementedError('This method must be implemented by a subclass.')


### PR DESCRIPTION
...hey are declared

Overview:
Field order was coming back in a random order, this made it harder to visually parse json returns. Using OrderedDict allows for the json serializer to know the order the fields were declared in the resource.

In branch: feature/json-field-order
