### PR TITLE
EM- add ordering to resource params

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from distutils.core import setup
 
 setup(name='Thorium',
-      version='0.1.32',
+      version='0.1.33',
       description='A Python framework for simple RESTful API interfaces',
       author='Ryan Easterbrook',
       author_email='ryan@eventmobi.com',

--- a/thorium/params.py
+++ b/thorium/params.py
@@ -3,10 +3,14 @@ from . import errors, validators, NotSet
 
 class ResourceParam(object):
     validator_type = None
+    order_counter = 0
 
     def __init__(self, default=NotSet, notnull=False, options=None, *args, **kwargs):
         self.flags = {'notnull': notnull, 'default': default, 'options': options}
         self.name = 'noname'
+
+        self.order_value = ResourceParam.order_counter
+        ResourceParam.order_counter += 1
 
         # a hook to allow subclasses to add their own unique parameters
         self.set_unique_attributes(**kwargs)


### PR DESCRIPTION
In branch: feature/params-ordering

ResourceParams will now have an order_value similar to ResourceFields.
