### PR TITLE
change CharValidator attempt_cast to try isoformat() first

### DIFF
--- a/thorium/validators.py
+++ b/thorium/validators.py
@@ -69,6 +69,8 @@ class CharValidator(FieldValidator):
         return isinstance(value, str)
 
     def attempt_cast(self, value):
+        if hasattr(value, 'isoformat'):
+            return value.isoformat()
         return str(value)
 
     def raise_validation_error(self, value):


### PR DESCRIPTION
This mainly pertains to casts between `datetime` objects and strings, but there are discrepancies between `str()` and the ISO formats of some objects.

For example, when casting a `datetime` object to a `CharField`, the datetime is cast to the format `%Y-%m-%d %H:%M:%S` because of [how `str()` works for `datetime.datetime`](https://docs.python.org/3.3/library/datetime.html#datetime.datetime.__str__). However, when casting a string to a `DateTimeField`, the validator tries to cast the string to the ISO format `%Y-%m-%dT%H:%M:%S`, which obviously will cause errors when working with values that are passed back and forth between `CharField`s and `DateTimeField`s.

Not sure if this is actually a problem, but opening a PR to fix it just in case.
