### PR TITLE
PLAT-154 added order-by and pagination functionality in thorium before f...

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name='Thorium',
-    version='0.1.41',
+    version='0.1.42',
     description='A Python framework for RESTful API interfaces in Flask',
     author='Ryan Easterbrook',
     author_email='ryan@eventmobi.com',

--- a/thorium/dispatcher.py
+++ b/thorium/dispatcher.py
@@ -1,14 +1,19 @@
+# -*- coding: utf-8 -*-
+
 from . import errors
 from .response import DetailResponse, CollectionResponse
 from .serializer import JsonSerializer
 
 
 class DispatcherBase(object):
-    """ The Dispatcher holds a :class:`.ResourceInterface` and :class:`.Endpoint` pairing and is associated
-    with a :class:`.Route`. It's responsible for handing a request off to the correct components.
+    """
+    The Dispatcher holds a :class:`.ResourceInterface` and :class:`.Endpoint`
+    pairing and is associated with a :class:`.Route`. It's responsible for
+    handing a request off to the correct components.
 
     :param resource_cls: A :class:`.Resource` class definition
-    :param engine: A :class:`.Endpoint` object to implement the :class:`.ResourceInterface`
+    :param engine: A :class:`.Endpoint` object to implement the
+        :class:`.ResourceInterface`
     """
 
     def __init__(self, endpoint_cls, resource_cls, parameters_cls,
@@ -19,20 +24,23 @@ class DispatcherBase(object):
         self.allowed_methods = {method.upper() for method in allowed_methods}
 
     def dispatch(self, request):
-        """ Injects the :class:`.ResourceInterface` into the :class:`.Endpoint`
-        then calls a method on the engine to handle the request based
-        on the :class:`.ThoriumRequest`.
+        """
+        Injects the :class:`.ResourceInterface` into the :class:`.Endpoint`
+        then calls a method on the engine to handle the request based on the
+        :class:`.ThoriumRequest`.
 
         :param request: A :class:`.ThoriumRequest` object
         """
 
         # ensure valid method
         if request.method not in self.allowed_methods:
-            msg = 'Method {0} not available on {1} {2} resource.' \
-                .format(request.method, self.Resource.__name__,
-                        self.request_type)
-            raise errors.MethodNotAllowedError(message=msg, headers={
-            'Allow': ', '.join(self.allowed_methods)})
+            msg = ('Method {0} not available on {1} {2} resource.'
+                   .format(request.method,
+                           self.Resource.__name__,
+                           self.request_type))
+            raise errors.MethodNotAllowedError(
+                message=msg, headers={'Allow': ', '.join(self.allowed_methods)}
+            )
 
         response = self.build_response_obj(request=request)
 
@@ -70,7 +78,10 @@ class DispatcherBase(object):
 
 
 class CollectionDispatcher(DispatcherBase):
-    """ A subclass of :class:`.DispatcherBase` to handle requests made on collections of :class:`.Resource`'s """
+    """
+    A subclass of :class:`.DispatcherBase` to handle requests made on
+    collections of :class:`.Resource`'s
+    """
     request_type = 'collection'
 
     def pre_request(self, engine):
@@ -86,7 +97,10 @@ class CollectionDispatcher(DispatcherBase):
 
 
 class DetailDispatcher(DispatcherBase):
-    """ A subclass of :class:`.DispatcherBase` to handle requests made on individual :class:`.Resource`'s """
+    """
+    A subclass of :class:`.DispatcherBase` to handle requests made on
+    individual :class:`.Resource`'s
+    """
     request_type = 'detail'
 
     def pre_request(self, engine):
@@ -94,12 +108,3 @@ class DetailDispatcher(DispatcherBase):
 
     def build_response_obj(self, request):
         return DetailResponse(request)
-
-
-
-
-
-
-
-
-

--- a/thorium/dispatcher.py
+++ b/thorium/dispatcher.py
@@ -11,7 +11,8 @@ class DispatcherBase(object):
     :param engine: A :class:`.Endpoint` object to implement the :class:`.ResourceInterface`
     """
 
-    def __init__(self, endpoint_cls, resource_cls, parameters_cls, allowed_methods):
+    def __init__(self, endpoint_cls, resource_cls, parameters_cls,
+                 allowed_methods):
         self.Endpoint = endpoint_cls
         self.Resource = resource_cls
         self.Parameters = parameters_cls
@@ -25,11 +26,13 @@ class DispatcherBase(object):
         :param request: A :class:`.ThoriumRequest` object
         """
 
-        #ensure valid method
+        # ensure valid method
         if request.method not in self.allowed_methods:
-            msg = 'Method {0} not available on {1} {2} resource.'\
-                .format(request.method, self.Resource.__name__, self.request_type)
-            raise errors.MethodNotAllowedError(message=msg, headers={'Allow': ', '.join(self.allowed_methods)})
+            msg = 'Method {0} not available on {1} {2} resource.' \
+                .format(request.method, self.Resource.__name__,
+                        self.request_type)
+            raise errors.MethodNotAllowedError(message=msg, headers={
+            'Allow': ', '.join(self.allowed_methods)})
 
         response = self.build_response_obj(request=request)
 
@@ -59,7 +62,8 @@ class DispatcherBase(object):
 
     def get_dispatch_method(self, engine):
         """ find the method in the engine that matches the request """
-        return getattr(engine, "{0}_{1}".format(engine.request.method.lower(), self.request_type))
+        return getattr(engine, "{0}_{1}".format(engine.request.method.lower(),
+                                                self.request_type))
 
     def get_serializer(self):
         return JsonSerializer()
@@ -77,7 +81,7 @@ class CollectionDispatcher(DispatcherBase):
         if method == 'post':
             response = DetailResponse(request)
         else:
-            response = CollectionResponse(request)
+            response = CollectionResponse(request=request)
         return response
 
 

--- a/thorium/resources.py
+++ b/thorium/resources.py
@@ -52,6 +52,9 @@ class Resource(object, metaclass=ResourceMetaClass):
 
     def __init__(self, *args, **kwargs):
         self._partial = getattr(self, '_partial', False)
+        self.sort = None
+        self.offset = None
+        self.limit = None
         self._init(*args, **kwargs)
 
     @classmethod

--- a/thorium/resources.py
+++ b/thorium/resources.py
@@ -1,8 +1,7 @@
 from . import errors, fields, NotSet
-import copy
-import collections
 
 VALID_METHODS = {'get', 'post', 'put', 'patch', 'delete', 'options'}
+VALID_QUERY_PARAMETERS = {'sort', 'offset', 'limit'}
 
 
 class ResourceMetaClass(type):

--- a/thorium/resources.py
+++ b/thorium/resources.py
@@ -1,4 +1,7 @@
+# -*- coding: utf-8 -*-
+
 from . import errors, fields, NotSet
+
 
 VALID_METHODS = {'get', 'post', 'put', 'patch', 'delete', 'options'}
 VALID_QUERY_PARAMETERS = {'sort', 'offset', 'limit'}

--- a/thorium/response.py
+++ b/thorium/response.py
@@ -1,8 +1,8 @@
 from collections import OrderedDict
-
+from operator import attrgetter
+from . import errors
 
 class Response(object):
-
     def __init__(self, request):
         self.meta = {}
         self.headers = {}
@@ -30,11 +30,11 @@ class Response(object):
             return 200
 
     def get_response_data(self):
-        raise NotImplementedError('This method must be overridden by subclass.')
+        raise NotImplementedError(
+            'This method must be overridden by subclass.')
 
 
 class DetailResponse(Response):
-
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.response_type = 'detail'
@@ -48,22 +48,51 @@ class DetailResponse(Response):
 
 
 class CollectionResponse(Response):
-
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.response_type = 'collection'
         self.resources = []
+        request = kwargs.get('request')
+        self.sort = request.params.sort if hasattr(request.params,
+                                                   'sort') else None
+        self.offset = request.params.page if hasattr(request.params,
+                                                   'offset') else None
+        self.limit = request.params.per_page if hasattr(request.params,
+                                                           'limit') else None
 
     def get_response_data(self):
         data = []
         if self.resources:
+            self._sort()
+            self._paginate()
             for res in self.resources:
                 data.append(OrderedDict(res.sorted_items()))
         return data
 
+    def _sort(self):
+        if self.sort:
+            reverse = self._check_and_strip_first_char()
+            sort_by = self.sort.split(
+                ',')  # split query parameters into a list
+            try:
+                self.resources.sort(key=attrgetter(*sort_by),
+                                    reverse=reverse)
+            except:
+                raise errors.BadRequestError('Sort parameter doens\'t exist as a field')
+
+    def _paginate(self):
+        if self.offset and self.limit:
+            end = self.offset + self.limit + 1
+            self.resources = self.resources[self.offset:end]
+
+    def _check_and_strip_first_char(self):
+        reverse = True if self.sort.startswith('-') else False
+        self.sort = self.sort.strip('+')
+        self.sort = self.sort.strip('-')
+        return reverse
+
 
 class ErrorResponse(Response):
-
     def __init__(self, http_error, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.response_type = 'error'

--- a/thorium/response.py
+++ b/thorium/response.py
@@ -99,8 +99,6 @@ class CollectionResponse(Response):
             self.resources = self.resources[start:end]
 
     def _check_and_strip_first_char(self):
-        if not self.sort.startswith('+') and not self.sort.startswith('-'):
-            raise errors.BadRequestError('Sort requires direction to sort by.')
         self.meta['sort'] = self.sort
         reverse = self.sort.startswith('-')
         self.sort = self.sort.lstrip('+-')

--- a/thorium/testsuite/test_response.py
+++ b/thorium/testsuite/test_response.py
@@ -4,7 +4,7 @@ from unittest import TestCase, mock
 
 from thorium.response import (Response, DetailResponse, CollectionResponse,
                               ErrorResponse)
-from thorium.errors import MethodNotAllowedError
+from thorium.errors import MethodNotAllowedError, BadRequestError
 from thorium import Resource, fields
 
 
@@ -56,10 +56,17 @@ class TestCollectionResponse(TestCase):
 
     def setUp(self):
         self.request_mock = mock.MagicMock()
-        del self.request_mock.params.sort
-        del self.request_mock.params.limit
-        del self.request_mock.params.offset
+        self.request_mock.params.sort = None
+        self.request_mock.params.offset = None
+        self.request_mock.params.limit = None
         self.response = CollectionResponse(request=self.request_mock)
+        self.test_data = [
+            SimpleResource(id=1, name='a'),
+            SimpleResource(id=2, name='c'),
+            SimpleResource(id=4, name='b'),
+            SimpleResource(id=3, name='d'),
+            SimpleResource(id=5, name='d'),
+        ]
 
     def test_attributes(self):
         self.assertEqual(self.response.status_code, 200)
@@ -77,39 +84,119 @@ class TestCollectionResponse(TestCase):
         data = self.response.get_response_data()
         self.assertEqual(data, [{'id': 1, 'name': 'a'}])
 
-    def test_get_response_data_sorted_by_id(self):
-        self.response.resources = [SimpleResource(id=2, name='c'),
-                                   SimpleResource(id=1, name='a'),
-                                   SimpleResource(id=3, name='b')]
+    def test_get_response_data_sort_ascending(self):
+        self.response.resources = self.test_data
         self.response.sort = '+id'
         data = self.response.get_response_data()
+        self.assertEqual(len(data), len(self.test_data))
         self.assertEqual(data[0], {'id': 1, 'name': 'a'})
         self.assertEqual(data[1], {'id': 2, 'name': 'c'})
-        self.assertEqual(data[2], {'id': 3, 'name': 'b'})
+        self.assertEqual(data[2], {'id': 3, 'name': 'd'})
+        self.assertEqual(data[3], {'id': 4, 'name': 'b'})
+        self.assertEqual(data[4], {'id': 5, 'name': 'd'})
 
-    def test_get_response_data_sorted_by_name_and_id(self):
-        self.response.resources = [SimpleResource(id=1, name='a'),
-                                   SimpleResource(id=2, name='c'),
-                                   SimpleResource(id=4, name='b'),
-                                   SimpleResource(id=3, name='b')]
+    def test_get_response_data_sort_ascending_multiple(self):
+        self.response.resources = self.test_data
         self.response.sort = '+name,id'
         data = self.response.get_response_data()
+        self.assertEqual(len(data), len(self.test_data))
         self.assertEqual(data[0], {'id': 1, 'name': 'a'})
-        self.assertEqual(data[1], {'id': 3, 'name': 'b'})
-        self.assertEqual(data[2], {'id': 4, 'name': 'b'})
+        self.assertEqual(data[1], {'id': 4, 'name': 'b'})
+        self.assertEqual(data[2], {'id': 2, 'name': 'c'})
+        self.assertEqual(data[3], {'id': 3, 'name': 'd'})
+        self.assertEqual(data[4], {'id': 5, 'name': 'd'})
+
+    def test_get_response_data_sort_descending(self):
+        self.response.resources = self.test_data
+        self.response.sort = '-id'
+        data = self.response.get_response_data()
+        self.assertEqual(len(data), len(self.test_data))
+        self.assertEqual(data[0], {'id': 5, 'name': 'd'})
+        self.assertEqual(data[1], {'id': 4, 'name': 'b'})
+        self.assertEqual(data[2], {'id': 3, 'name': 'd'})
         self.assertEqual(data[3], {'id': 2, 'name': 'c'})
+        self.assertEqual(data[4], {'id': 1, 'name': 'a'})
+
+    def test_get_response_data_sort_descending_multiple(self):
+        self.response.resources = self.test_data
+        self.response.sort = '-name,id'
+        data = self.response.get_response_data()
+        self.assertEqual(len(data), len(self.test_data))
+        self.assertEqual(data[0], {'id': 5, 'name': 'd'})
+        self.assertEqual(data[1], {'id': 3, 'name': 'd'})
+        self.assertEqual(data[2], {'id': 2, 'name': 'c'})
+        self.assertEqual(data[3], {'id': 4, 'name': 'b'})
+        self.assertEqual(data[4], {'id': 1, 'name': 'a'})
+
+    def test_get_response_data_sort_invalid(self):
+        self.response.resources = self.test_data
+        self.response.sort = 'id'
+        self.assertRaises(BadRequestError, self.response.get_response_data)
+
+        self.response.sort = '+NotAField'
+        self.assertRaises(BadRequestError, self.response.get_response_data)
 
     def test_get_response_data_paginate(self):
-        self.response.resources = [SimpleResource(id=1, name='a'),
-                                   SimpleResource(id=2, name='c'),
-                                   SimpleResource(id=3, name='b'),
-                                   SimpleResource(id=4, name='d')]
+        self.response.resources = self.test_data
+        self.response.offset = 1
+        self.response.limit = 1
+        data = self.response.get_response_data()
+        self.assertEqual(len(data), 1)
+        self.assertEqual(data[0], {'id': 2, 'name': 'c'})
+
+    def test_get_response_data_paginate_cast(self):
+        self.response.resources = self.test_data
+        self.response.sort = '+id'
+        self.response.offset = '2'
+        self.response.limit = '2'
+        data = self.response.get_response_data()
+        self.assertEqual(len(data), 2)
+        self.assertEqual(data[0], {'id': 3, 'name': 'd'})
+        self.assertEqual(data[1], {'id': 4, 'name': 'b'})
+
+    def test_get_response_data_paginate_with_sort(self):
+        self.response.resources = self.test_data
         self.response.sort = '-name'
         self.response.limit = 2
         self.response.offset = 2
         data = self.response.get_response_data()
+        self.assertEqual(len(data), 2)
         self.assertEqual(data[0], {'id': 2, 'name': 'c'})
-        self.assertEqual(data[1], {'id': 3, 'name': 'b'})
+        self.assertEqual(data[1], {'id': 4, 'name': 'b'})
+
+    def test_get_response_data_pagination_out_of_bounds(self):
+        self.response.resources = self.test_data
+        self.response.offset = 5
+        self.response.limit = 10
+        data = self.response.get_response_data()
+        self.assertEqual(data, [])
+
+    def test_get_response_data_invalid_offset(self):
+        self.response.resources = self.test_data
+        self.response.offset = -1
+        self.response.limit = 10
+        self.assertRaises(BadRequestError, self.response.get_response_data)
+
+        self.response.offset = ''
+        self.assertRaises(BadRequestError, self.response.get_response_data)
+
+        self.response.offset = True
+        self.assertRaises(BadRequestError, self.response.get_response_data)
+
+    def test_get_response_data_invalid_limit(self):
+        self.response.resources = self.test_data
+        self.response.offset = 0
+        self.response.limit = 0
+        self.assertRaises(BadRequestError, self.response.get_response_data)
+
+        self.response.limit = -1
+        self.assertRaises(BadRequestError, self.response.get_response_data)
+
+        self.response.limit = 'infinity'
+        self.assertRaises(BadRequestError, self.response.get_response_data)
+
+        self.response.limit = False
+        self.assertRaises(BadRequestError, self.response.get_response_data)
 
 
 class TestErrorResponse(TestCase):

--- a/thorium/testsuite/test_response.py
+++ b/thorium/testsuite/test_response.py
@@ -97,7 +97,7 @@ class TestCollectionResponse(TestCase):
 
     def test_get_response_data_sort_ascending_multiple(self):
         self.response.resources = self.test_data
-        self.response.sort = '+name,id'
+        self.response.sort = 'name,id'
         data = self.response.get_response_data()
         self.assertEqual(len(data), len(self.test_data))
         self.assertEqual(data[0], {'id': 1, 'name': 'a'})
@@ -130,9 +130,6 @@ class TestCollectionResponse(TestCase):
 
     def test_get_response_data_sort_invalid(self):
         self.response.resources = self.test_data
-        self.response.sort = 'id'
-        self.assertRaises(BadRequestError, self.response.get_response_data)
-
         self.response.sort = '+NotAField'
         self.assertRaises(BadRequestError, self.response.get_response_data)
 

--- a/thorium/testsuite/test_response.py
+++ b/thorium/testsuite/test_response.py
@@ -1,6 +1,9 @@
+# -*- coding: utf-8 -*-
+
 from unittest import TestCase, mock
-from thorium.response import Response, DetailResponse, CollectionResponse, \
-    ErrorResponse
+
+from thorium.response import (Response, DetailResponse, CollectionResponse,
+                              ErrorResponse)
 from thorium.errors import MethodNotAllowedError
 from thorium import Resource, fields
 
@@ -11,6 +14,7 @@ class SimpleResource(Resource):
 
 
 class TestResponse(TestCase):
+
     def setUp(self):
         self.request_mock = mock.MagicMock()
         self.response = Response(request=self.request_mock)
@@ -26,6 +30,7 @@ class TestResponse(TestCase):
 
 
 class TestDetailResponse(TestCase):
+
     def setUp(self):
         self.request_mock = mock.MagicMock()
         self.response = DetailResponse(request=self.request_mock)
@@ -48,6 +53,7 @@ class TestDetailResponse(TestCase):
 
 
 class TestCollectionResponse(TestCase):
+
     def setUp(self):
         self.request_mock = mock.MagicMock()
         del self.request_mock.params.sort
@@ -85,8 +91,7 @@ class TestCollectionResponse(TestCase):
         self.response.resources = [SimpleResource(id=1, name='a'),
                                    SimpleResource(id=2, name='c'),
                                    SimpleResource(id=4, name='b'),
-                                   SimpleResource(id=3, name='b')
-        ]
+                                   SimpleResource(id=3, name='b')]
         self.response.sort = '+name,id'
         data = self.response.get_response_data()
         self.assertEqual(data[0], {'id': 1, 'name': 'a'})
@@ -103,11 +108,12 @@ class TestCollectionResponse(TestCase):
         self.response.limit = 2
         self.response.offset = 2
         data = self.response.get_response_data()
-        self.assertEqual(data[0], {'id': 3, 'name': 'b'})
-        self.assertEqual(data[1], {'id': 1, 'name': 'a'})
+        self.assertEqual(data[0], {'id': 2, 'name': 'c'})
+        self.assertEqual(data[1], {'id': 3, 'name': 'b'})
 
 
 class TestErrorResponse(TestCase):
+
     def setUp(self):
         self.request_mock = mock.MagicMock()
         self.error = MethodNotAllowedError()

--- a/thorium/testsuite/test_serializer.py
+++ b/thorium/testsuite/test_serializer.py
@@ -1,6 +1,10 @@
+# -*- coding: utf-8 -*-
+
 import unittest
 import json
+
 from unittest import mock
+
 from thorium.response import CollectionResponse, DetailResponse, ErrorResponse
 from thorium.serializer import JsonSerializer
 from thorium.errors import MethodNotAllowedError
@@ -18,9 +22,10 @@ class TestJsonSerializer(unittest.TestCase):
         self.serializer = JsonSerializer()
         self.data = {'id': 1, 'name': 'Jim'}
         self.request = mock.MagicMock()
+        self.request.params = None
 
     def test_serialize_collection_response(self):
-        collection_response = CollectionResponse(self.request)
+        collection_response = CollectionResponse(request=self.request)
         collection_response.resources = [SimpleResource(self.data)]
         serialized_data = self.serializer.serialize_response(collection_response)
         data = json.loads(serialized_data)
@@ -31,10 +36,10 @@ class TestJsonSerializer(unittest.TestCase):
             "meta": {},
             "data": [self.data]
         }
-        self.assertEqual(data, expected_data)
+        self.assertDictEqual(data, expected_data)
 
     def test_serialize_empty_collection_response(self):
-        collection_response = CollectionResponse(self.request)
+        collection_response = CollectionResponse(request=self.request)
         serialized_data = self.serializer.serialize_response(collection_response)
         data = json.loads(serialized_data)
         expected_data = {

--- a/thorium/testsuite/test_thoriumflask.py
+++ b/thorium/testsuite/test_thoriumflask.py
@@ -134,14 +134,7 @@ class TestThoriumFlask(unittest.TestCase):
             })
 
     def test_get_with_sort_invalid(self):
-        rv = self.c.open('/api/event/1/people?times=5&sort=id', method='GET')
-        self.assertEqual(rv.status_code, 400)
-
         rv = self.c.open('/api/event/1/people?times=5&sort=+YO', method='GET')
-        self.assertEqual(rv.status_code, 400)
-
-        rv = self.c.open('/api/event/1/people?times=5&sort=id,name',
-                         method='GET')
         self.assertEqual(rv.status_code, 400)
 
         rv = self.c.open('/api/event/1/people?times=5&sort=+id,None',

--- a/thorium/thoriumflask.py
+++ b/thorium/thoriumflask.py
@@ -1,10 +1,13 @@
 import traceback
+
 from . import Thorium, errors
 from .request import Request
-from .resources import VALID_METHODS
+from .resources import VALID_METHODS, VALID_QUERY_PARAMETERS
 from .parameters import ParametersMetaClass
-from flask import Response as FlaskResponse, request as flaskrequest
 from .crossdomain_decorator import crossdomain
+
+from flask import Response as FlaskResponse, request as flaskrequest
+
 from werkzeug.exceptions import BadRequest as WerkzeugBadRequest
 
 
@@ -108,5 +111,5 @@ class FlaskEndpoint(object):
     def _validate_no_extra_query_params(self, flask_params):
         param_fields = dict(self.dispatcher.Parameters.all_fields())
         for name, param in flask_params.items():
-            if name not in param_fields:
+            if name not in (param_fields or VALID_QUERY_PARAMETERS):
                 raise errors.ValidationError(name + ' is not a supported query parameter.')

--- a/thorium/thoriumflask.py
+++ b/thorium/thoriumflask.py
@@ -1,4 +1,9 @@
+# -*- coding: utf-8 -*-
+
 import traceback
+
+from flask import Response as FlaskResponse, request as flaskrequest
+from werkzeug.exceptions import BadRequest as WerkzeugBadRequest
 
 from . import Thorium, errors
 from .request import Request
@@ -6,24 +11,33 @@ from .resources import VALID_METHODS, VALID_QUERY_PARAMETERS
 from .parameters import ParametersMetaClass
 from .crossdomain_decorator import crossdomain
 
-from flask import Response as FlaskResponse, request as flaskrequest
-
-from werkzeug.exceptions import BadRequest as WerkzeugBadRequest
-
 
 class ThoriumFlask(Thorium):
 
     def __init__(self, settings, route_manager, flask_app):
         self._flask_app = flask_app
-        super(ThoriumFlask, self).__init__(settings=settings, route_manager=route_manager, debug=self._flask_app.debug)
+        super(ThoriumFlask, self).__init__(
+            settings=settings,
+            route_manager=route_manager,
+            debug=self._flask_app.debug,
+        )
 
     def _bind_routes(self):
         routes = self._route_manager.get_all_routes()
         for r in routes:
             if r.path:
-                fep = FlaskEndpoint(r.dispatcher, self.exception_handler, self._flask_app.config)
+                fep = FlaskEndpoint(
+                    dispatcher=r.dispatcher,
+                    exception_handler=self.exception_handler,
+                    flask_config=self._flask_app.config,
+                )
                 fep.__name__ = r.name
-                self._flask_app.add_url_rule(r.path, r.name, fep.endpoint_target, methods=VALID_METHODS)
+                self._flask_app.add_url_rule(
+                    rule=r.path,
+                    endpoint=r.name,
+                    view_func=fep.endpoint_target,
+                    methods=VALID_METHODS,
+                )
 
 
 class FlaskEndpoint(object):
@@ -31,7 +45,8 @@ class FlaskEndpoint(object):
     def __init__(self, dispatcher, exception_handler, flask_config):
         self.flask_config = flask_config
         self.dispatcher = dispatcher
-        self.exception_handler = exception_handler  # should this just have a reference to the thorium object?
+        # should this just have a reference to the thorium object?
+        self.exception_handler = exception_handler
 
     @crossdomain(origin='*')
     def endpoint_target(self, **kwargs):
@@ -42,18 +57,40 @@ class FlaskEndpoint(object):
             url = request.url
             method = request.method
             response, serialized_body = self.dispatcher.dispatch(request)
-            return FlaskResponse(response=serialized_body, headers=response.headers,
-                                 status=response.status_code, content_type='application/json')
+            return FlaskResponse(
+                response=serialized_body,
+                headers=response.headers,
+                status=response.status_code,
+                content_type='application/json',
+            )
         except errors.HttpErrorBase as e:
-            error_body = self.exception_handler.handle_http_exception(e, request)
-            return FlaskResponse(response=error_body, status=e.status_code,
-                                 headers=e.headers, content_type='application/json')
+            error_body = self.exception_handler.handle_http_exception(
+                http_error=e,
+                request=request,
+            )
+            return FlaskResponse(
+                response=error_body,
+                status=e.status_code,
+                headers=e.headers,
+                content_type='application/json',
+            )
         except Exception as e:
             traceback.print_exc()
-            error_body = self.exception_handler.handle_general_exception(url, method, e, request)
-            if self.flask_config['DEBUG']:  # if flask debug raise exception instead of returning json response
+            error_body = self.exception_handler.handle_general_exception(
+                url=url,
+                method=method,
+                e=e,
+                request=request,
+            )
+            # if flask debug raise exception instead of returning json response
+            if self.flask_config['DEBUG']:
                 raise e
-            return FlaskResponse(response=error_body, status=500, headers={}, content_type='application/json')
+            return FlaskResponse(
+                response=error_body,
+                status=500,
+                headers={},
+                content_type='application/json',
+            )
 
     def build_request(self):
         try:
@@ -72,11 +109,20 @@ class FlaskEndpoint(object):
                         resource = self._create_resource(json_data, partial)
 
                 else:
-                    raise errors.BadRequestError('Currently only json is supported, use application/json mimetype')
+                    raise errors.BadRequestError(
+                        'Currently only json is supported, use application/'
+                        'json mimetype')
 
-            return Request(dispatcher=self.dispatcher, method=flaskrequest.method, identifiers=flaskrequest.view_args,
-                           query_params=self._build_parameters(), mimetype=flaskrequest.mimetype, resource=resource,
-                           resources=resources, url=flaskrequest.url)
+            return Request(
+                dispatcher=self.dispatcher,
+                method=flaskrequest.method,
+                identifiers=flaskrequest.view_args,
+                query_params=self._build_parameters(),
+                mimetype=flaskrequest.mimetype,
+                resource=resource,
+                resources=resources,
+                url=flaskrequest.url,
+            )
         except (errors.ValidationError, WerkzeugBadRequest) as e:
             traceback.print_exc()
             raise errors.BadRequestError(message=e.args[0] if e.args else None)
@@ -88,7 +134,8 @@ class FlaskEndpoint(object):
         else:
             resource = self.dispatcher.Resource(data)
 
-        # Overrides readonly fields with their default values, not sure if this is the best approach to readonly
+        # Overrides readonly fields with their default values
+        # not sure if this is the best approach to readonly
         for name, field in resource.all_fields():
             if field.is_readonly:
                 resource.to_default(name)
@@ -106,10 +153,22 @@ class FlaskEndpoint(object):
         else:
             self._validate_no_extra_query_params(flask_params)
             flask_params.update(flaskrequest.view_args)
-            return self.dispatcher.Parameters.init_from_dict(data=flask_params, partial=True, cast=True)
+            params = self.dispatcher.Parameters.init_from_dict(
+                data=flask_params,
+                partial=True,
+                cast=True,
+            )
+            params.sort = flask_params.get('sort')
+            params.offset = flask_params.get('offset')
+            params.limit = flask_params.get('limit')
+            if not params.limit:
+                params.limit = self.flask_config.get('PAGINATION_LIMIT')
+            return params
 
     def _validate_no_extra_query_params(self, flask_params):
         param_fields = dict(self.dispatcher.Parameters.all_fields())
         for name, param in flask_params.items():
-            if name not in (param_fields or VALID_QUERY_PARAMETERS):
-                raise errors.ValidationError(name + ' is not a supported query parameter.')
+            if name not in param_fields and name not in VALID_QUERY_PARAMETERS:
+                raise errors.ValidationError(
+                    '{0} is not a supported query parameter.'.format(name)
+                )


### PR DESCRIPTION
#### What's this PR do?
It adds order-by and pagination functionality in thorium so when multiple items are retrieved from Flux, an order and a specific subset of items may be returned instead of all. These functionalities are used through the query parameters `sort`, `offset`, and `limit`. 

`sort` takes in `+` or `-` to signify ascending/descending respectively plus the field(s) upon which to sort. Example: 
```
# sorts by id in ascending order
# if the ids are the same, it will then sort by name
'sort=+id,name' 
```
`offset` and `limit` indicate the range of items to return. Both params are required for pagination.
Example: 
```
# returns items 50-75
'offset=50&limit=25'
```
