### PR TITLE
Feature/plat 267 add mutable field attribute

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name='Thorium',
-    version='0.1.42',
+    version='0.1.43',
     description='A Python framework for RESTful API interfaces in Flask',
     author='Ryan Easterbrook',
     author_email='ryan@eventmobi.com',

--- a/thorium/fields.py
+++ b/thorium/fields.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 from . import errors, validators, NotSet
 
 
@@ -5,8 +7,9 @@ class ResourceField(object):
     validator_type = None
     order_counter = 0
 
-    def __init__(self, default=NotSet, notnull=False, readonly=False, writeonly=False, options=None, cast=None,
-                 required=False, *args, **kwargs):
+    def __init__(self, default=NotSet, notnull=False, readonly=False,
+                 writeonly=False, options=None, cast=None, required=False,
+                 mutable=True, *args, **kwargs):
         self.flags = {
             'notnull': notnull,
             'readonly': readonly,
@@ -14,7 +17,8 @@ class ResourceField(object):
             'writeonly': writeonly,
             'options': options,
             'cast': cast,
-            'required': required
+            'required': required,
+            'mutable': mutable,
         }
 
         self.name = 'noname'
@@ -44,6 +48,10 @@ class ResourceField(object):
     @property
     def is_required(self):
         return self.flags['required']
+
+    @property
+    def is_mutable(self):
+        return self.flags['mutable']
 
     @property
     def default(self):

--- a/thorium/fields.py
+++ b/thorium/fields.py
@@ -9,7 +9,7 @@ class ResourceField(object):
 
     def __init__(self, default=NotSet, notnull=False, readonly=False,
                  writeonly=False, options=None, cast=None, required=False,
-                 mutable=True, *args, **kwargs):
+                 *args, **kwargs):
         self.flags = {
             'notnull': notnull,
             'readonly': readonly,
@@ -18,7 +18,6 @@ class ResourceField(object):
             'options': options,
             'cast': cast,
             'required': required,
-            'mutable': mutable,
         }
 
         self.name = 'noname'
@@ -50,15 +49,12 @@ class ResourceField(object):
         return self.flags['required']
 
     @property
-    def is_mutable(self):
-        return self.flags['mutable']
-
-    @property
     def default(self):
         return self.flags['default']
 
     def set_unique_attributes(self, **kwargs):
-        pass
+        for key, value in kwargs.items():
+            self.flags[key] = value
 
     def _get_validator(self):
         if self.validator_type:

--- a/thorium/resources.py
+++ b/thorium/resources.py
@@ -249,7 +249,7 @@ class Resource(object, metaclass=ResourceMetaClass):
 
     def _validate_full(self):
         for name, field in self._fields.items():
-            if not self.is_set(name) and not field.is_readonly and field.is_mutable:
+            if not self.is_set(name) and not field.is_readonly:
                 raise errors.ValidationError(
                     'Field {0} is NotSet, expected full resource.'
                     .format(field)
@@ -275,7 +275,7 @@ class Resource(object, metaclass=ResourceMetaClass):
 
     def _set(self, field_name, value, cast=False):
         field = self._fields[field_name]
-        if not self._partial and not field.is_readonly and field.is_mutable and value == NotSet:
+        if not self._partial and not field.is_readonly and value == NotSet:
             raise errors.ValidationError(
                 'Attempted to set field {0} of a non-partial resource to '
                 'NotSet'.format(field)

--- a/thorium/resources.py
+++ b/thorium/resources.py
@@ -9,24 +9,29 @@ VALID_QUERY_PARAMETERS = {'sort', 'offset', 'limit'}
 
 class ResourceMetaClass(type):
 
-    #Note: attrs comes in alphabetical order, unsure how to maintain declared order of fields
+    # Note: attrs comes in alphabetical order,
+    # unsure how to maintain declared order of fields
     def __new__(mcs, resource_name, bases, attrs):
         attrs['_fields'] = mcs._get_fields(bases, attrs)
         return super().__new__(mcs, resource_name, bases, attrs)
 
-    #Note: will likely need some sort of sorted dictionary to maintain field order
+    # Note: will likely need some sort of sorted dictionary to maintain
+    # field order
     @staticmethod
     def _get_fields(bases, attrs):
 
         # gather fields to add to _fields dictionary
-        # also replaces field definition with a property to wrap the _fields dictionary
+        # also replaces field definition with a property to wrap the
+        # _fields dictionary
         field_dict = {}
         for name, field in attrs.items():
             if isinstance(field, fields.ResourceField):
                 field.name = name
                 field_dict[name] = field
-                attrs[name] = property(fget=ResourceMetaClass._gen_get_prop(name),
-                                       fset=ResourceMetaClass._get_set_prop(name))
+                attrs[name] = property(
+                    fget=ResourceMetaClass._gen_get_prop(name),
+                    fset=ResourceMetaClass._get_set_prop(name),
+                )
         return field_dict
 
     @staticmethod
@@ -69,7 +74,8 @@ class Resource(object, metaclass=ResourceMetaClass):
 
     # is there a better way to do this?
     @classmethod
-    def init_from_obj(cls, obj, partial=False, mapping=None, override=None, cast=False):
+    def init_from_obj(cls, obj, partial=False, mapping=None, override=None,
+                      cast=False):
         mapping = mapping if mapping else {}
         resource = cls.__new__(cls)
         resource._partial = partial
@@ -100,7 +106,10 @@ class Resource(object, metaclass=ResourceMetaClass):
         if args and len(args) == 1 and isinstance(args[0], dict):
             self.from_dict(args[0])
         elif args:
-            raise Exception('Resource initiation accepts only a dictionary or fields by keyword.')
+            raise Exception(
+                'Resource initiation accepts only a dictionary or fields by '
+                'keyword.'
+            )
         if kwargs:
             self.from_dict(kwargs)
         self.validate()
@@ -131,11 +140,12 @@ class Resource(object, metaclass=ResourceMetaClass):
 
     def from_obj(self, obj, mapping=None, override=None, cast=False):
         """
-        Maps the public attributes from a object to the resource fields based on identical names.
-        Optional mapping parameter allows for discrepancies in naming with resource names being the
-        key and the object attribute name to map to being the value. If explicit_mapping is True,
-        only the attributes in the mapping dictionary will be copied. An optional override dictionary
-        is used to set values explicitly.
+        Maps the public attributes from a object to the resource fields based
+        on identical names. Optional mapping parameter allows for discrepancies
+        in naming with resource names being the key and the object attribute
+        name to map to being the value. If explicit_mapping is True, only the
+        attributes in the mapping dictionary will be copied. An optional
+        override dictionary is used to set values explicitly.
         """
         if not override:
             override = {}
@@ -149,11 +159,12 @@ class Resource(object, metaclass=ResourceMetaClass):
             # if value isn't overridden, get it from the obj
             if value == NotSet:
 
-                # Convert name to mapped name if available, else use Resource's existing name
+                # Convert name to mapped name if available,
+                # else use Resource's existing name
                 if mapping and field_name in mapping:
                     mapped_name = mapping[field_name]
 
-                    # A None value for name indicates that we shouldn't map this field
+                    # None value indicates that we shouldn't map this field
                     if not mapped_name:
                         continue
 
@@ -169,16 +180,17 @@ class Resource(object, metaclass=ResourceMetaClass):
 
     def to_obj(self, obj, mapping=None, override=None):
         """
-        Maps the fields from the resource to an object based on identical names. Optional mapping
-        parameter allows for discrepancies in naming with resource names being the
-        key and the object attribute name to map to being the value. If explicit_mapping is True,
-        only the attributes in the mapping dictionary will be copied.
+        Maps the fields from the resource to an object based on identical
+        names. Optional mapping parameter allows for discrepancies in naming
+        with resource names being the key and the object attribute name to map
+        to being the value. If explicit_mapping is True, only the attributes in
+        the mapping dictionary will be copied.
         """
         if not override:
             override = {}
 
-        # Gets the names of all fields with set values, then adds any included in the override
-        # This allows even NotSet values to be overridden
+        # Gets the names of all fields with set values, then adds any included
+        # in the override. This allows even NotSet values to be overridden
         field_names = {n for n, f in self.valid_fields()} | set(override.keys())
 
         for field_name in field_names:
@@ -190,11 +202,12 @@ class Resource(object, metaclass=ResourceMetaClass):
             # if value isn't overridden, get it from the field
             if value == NotSet:
 
-                # Convert name to mapped name if available, else use Resource's existing name
+                # Convert name to mapped name if available,
+                # else use Resource's existing name
                 if mapping and field_name in mapping:
                     mapped_name = mapping[field_name]
 
-                    # A None value for name indicates that we should skip this field
+                    # None value indicates that we should skip this field
                     if not mapped_name:
                         continue
 
@@ -241,13 +254,18 @@ class Resource(object, metaclass=ResourceMetaClass):
             if not self.is_set(name) and not field.is_mutable:
                 self.to_default(name)
             if not self.is_set(name) and not field.is_readonly:
-                raise errors.ValidationError('Field {0} is NotSet, expected full resource.'.format(field))
+                raise errors.ValidationError(
+                    'Field {0} is NotSet, expected full resource.'
+                    .format(field)
+                )
 
     def _validate_partial(self):
         for name, field in self._fields.items():
             if not self.is_set(name) and field.is_required:
-                raise errors.ValidationError('Field {0} is required, cannot be NotSet even on a partial resource.'
-                                             .format(field))
+                raise errors.ValidationError(
+                    'Field {0} is required, cannot be NotSet even on a '
+                    'partial resource.'.format(field)
+                )
 
     def to_default(self, field_name):
         self._set(field_name, self._fields[field_name].default)
@@ -262,9 +280,17 @@ class Resource(object, metaclass=ResourceMetaClass):
     def _set(self, field_name, value, cast=False):
         field = self._fields[field_name]
         if not self._partial and not field.is_readonly and value == NotSet:
-            raise errors.ValidationError('Attempted to set field {0} of a non-partial resource to NotSet'.format(field))
-        if not field.is_mutable and self.is_set(field_name) and self._get(field_name) != (field.default or value):
-            raise errors.ValidationError('Attempted to change value of non-mutable field.')
+            raise errors.ValidationError(
+                'Attempted to set field {0} of a non-partial resource to '
+                'NotSet'.format(field)
+            )
+        if (not field.is_mutable and
+                self.is_set(field_name) and
+                self._get(field_name) != (field.default or value)):
+            raise errors.ValidationError(
+                'Attempted to update value of non-mutable field {0} to {1}.'
+                .format(field, value)
+            )
         self._values[field_name] = field.validate(value, cast=cast)
         return self._values[field_name]
 

--- a/thorium/testsuite/test_fields.py
+++ b/thorium/testsuite/test_fields.py
@@ -37,6 +37,25 @@ class TestNotSet(TestCase):
         self.assertTrue(hit)
 
 
+class TestExtraFlags(TestCase):
+
+    def setUp(self):
+        self.extra = {
+            'extra_bool': True,
+            'extra_str': 'Yes',
+            'extra_int': 100
+        }
+        self.field = fields.IntField(default=99, **self.extra)
+
+    def test_extra_flags(self):
+        self.assertEqual(self.field.flags['extra_bool'],
+                         self.extra['extra_bool'])
+        self.assertEqual(self.field.flags['extra_str'],
+                         self.extra['extra_str'])
+        self.assertEqual(self.field.flags['extra_int'],
+                         self.extra['extra_int'])
+
+
 class TestFieldValidator(TestCase):
 
     def setUp(self):

--- a/thorium/testsuite/test_resources.py
+++ b/thorium/testsuite/test_resources.py
@@ -8,7 +8,6 @@ class SimpleResource(resources.Resource):
     name = fields.CharField(default=None)
     age = fields.IntField(default=None)
     readonly = fields.IntField(readonly=True)
-    not_mutable = fields.IntField(mutable=False, default=0)
 
 
 class SimpleObj(object):
@@ -16,7 +15,6 @@ class SimpleObj(object):
         self.name = None
         self.age = None
         self.extra = None
-        self.not_mutable = None
 
 
 class TestSimpleResource(TestCase):
@@ -29,13 +27,11 @@ class TestSimpleResource(TestCase):
             'name': 'Fred',
             'age': 9001,
             'readonly': 10,
-            'not_mutable': 0
         }
         self.resource.from_dict(data)
         self.assertEqual(self.resource.name, data['name'])
         self.assertEqual(self.resource.age, data['age'])
         self.assertEqual(self.resource.readonly, data['readonly'])
-        self.assertEqual(self.resource.not_mutable, data['not_mutable'])
 
     def test_from_dict_invalid(self):
         data = {
@@ -66,7 +62,6 @@ class TestSimpleResource(TestCase):
         self.resource.from_dict(data)
         self.assertEqual(self.resource.name, data['name'])
         self.assertEqual(self.resource.age, None)
-        self.assertEqual(self.resource.not_mutable, 0)
 
     def test_to_dict(self):
         self.resource.name = 'Jack Daniel'
@@ -76,7 +71,6 @@ class TestSimpleResource(TestCase):
         self.assertTrue(isinstance(data, dict))
         self.assertEqual(self.resource.name, data['name'])
         self.assertEqual(self.resource.age, data['age'])
-        self.assertEqual(self.resource.not_mutable, data['not_mutable'])
 
         data2 = self.resource.to_dict()
         self.assertEqual(data, data2)
@@ -87,7 +81,6 @@ class TestSimpleResource(TestCase):
         self.assertTrue(isinstance(data, dict))
         self.assertEqual(res.name, data['name'])
         self.assertNotIn('age', data)
-        self.assertNotIn('not_mutable', data)
 
     def test_valid_fields(self):
         res = SimpleResource.partial(name='Arthur')
@@ -96,20 +89,17 @@ class TestSimpleResource(TestCase):
         valid_fields = dict(valid_fields)
         self.assertIn('name', valid_fields)
         self.assertNotIn('age', valid_fields)
-        self.assertNotIn('not_mutable', valid_fields)
         self.assertEqual(dict(res.items())['name'], 'Arthur')
 
     def test_valid_fields_with_defaults_is_not_set(self):
         res = SimpleResource.partial(name='Trillian')
         dict(res.all_fields())['age'].flags['default'] = 0
         self.assertEqual(res.age, NotSet)
-        self.assertEqual(res.not_mutable, NotSet)
         valid_fields = res.valid_fields()
         self.assertTrue(isinstance(valid_fields, types.GeneratorType))
         valid_fields = dict(valid_fields)
         self.assertIn('name', valid_fields)
         self.assertNotIn('age', valid_fields)
-        self.assertNotIn('not_mutable', valid_fields)
         self.assertEqual(dict(res.items())['name'], 'Trillian')
 
     def test_to_default(self):
@@ -125,7 +115,6 @@ class TestSimpleResource(TestCase):
             'name': 'Bob',
             'age': 401,
             'readonly': 1,
-            'not_mutable': 0
         }
         self.resource.from_dict(data)
         items = self.resource.items()
@@ -139,25 +128,19 @@ class TestSimpleResource(TestCase):
         self.assertEqual(self.resource.name, so.name)
         self.assertEqual(self.resource.age, so.age)
         self.assertEqual(None, so.extra)
-        self.assertEqual(self.resource.not_mutable, so.not_mutable)
 
     def test_obj_to_resource(self):
         so = SimpleObj()
         so.name = 'Slartibartfast'
         so.age = 5000050
-        so.not_mutable = 0
         self.resource.from_obj(so)
         self.assertEqual(self.resource.name, so.name)
         self.assertEqual(self.resource.age, so.age)
-        self.assertEqual(self.resource.not_mutable, so.not_mutable)
 
     def test_obj_to_resource_invalid(self):
         so = SimpleObj()
         so.name = 'somename'
         so.age = 'Not an age'
-        self.assertRaises(errors.ValidationError, self.resource.from_obj, so)
-
-        so.not_mutable = 123
         self.assertRaises(errors.ValidationError, self.resource.from_obj, so)
 
     def test_seperate_resource_instsances_do_not_share_data(self):
@@ -170,7 +153,7 @@ class ComplexResource(resources.Resource):
     name = fields.CharField(max_length=20)
     age = fields.IntField()
     admin = fields.BoolField(default=True)
-    birth_date = fields.DateTimeField(mutable=False)
+    birth_date = fields.DateTimeField()
 
 
 class ComplexObj(object):

--- a/thorium/testsuite/test_resources.py
+++ b/thorium/testsuite/test_resources.py
@@ -417,3 +417,9 @@ class TestComplexResource(TestCase):
         self.assertEqual(self.full.admin, co.administrator)
         self.assertEqual(self.full.birth_date, co.birth)
 
+    def test_resource_to_object_not_mutable_field(self):
+        co = ComplexObj()
+        co.birth = datetime.datetime(1995, 1, 1)
+        self.assertRaises(errors.BadRequestError,
+                          self.full.to_obj,
+                          co, co.resource_mapping)

--- a/thorium/testsuite/test_resources.py
+++ b/thorium/testsuite/test_resources.py
@@ -44,11 +44,6 @@ class TestSimpleResource(TestCase):
         }
         self.assertRaises(errors.ValidationError, self.resource.from_dict, data)
 
-        data = {
-            'not_mutable': 123
-        }
-        self.assertRaises(errors.ValidationError, self.resource.from_dict, data)
-
     def test_from_dict_extra_fields(self):
         data = {
             'name': 'Zaphod',
@@ -124,12 +119,6 @@ class TestSimpleResource(TestCase):
         res.to_default('name')
         self.assertEqual(res._values['name'], None)
         self.assertEqual(res.name, None)
-
-    def test_to_default_invalid(self):
-        res = SimpleResource.partial(not_mutable=123)
-        self.assertEqual(res._values['not_mutable'], 123)
-        self.assertEqual(res.not_mutable, 123)
-        self.assertRaises(errors.ValidationError, res.to_default, 'not_mutable')
 
     def test_items(self):
         data = {
@@ -233,7 +222,7 @@ class TestComplexResource(TestCase):
         self.assertEqual(res.name, None)
         self.assertEqual(res.age, None)
         self.assertEqual(res.admin, True)
-        self.assertEqual(res.birth_date, NotSet)
+        self.assertEqual(res.birth_date, None)
 
     def test_resource_init_from_obj_full(self):
         co = ComplexObj()
@@ -337,7 +326,6 @@ class TestComplexResource(TestCase):
         self.assertRaises(errors.ValidationError, setattr, self.full, 'name', NotSet)
         self.assertRaises(errors.ValidationError, setattr, self.full, 'age', NotSet)
         self.assertRaises(errors.ValidationError, setattr, self.full, 'admin', NotSet)
-        self.assertRaises(errors.ValidationError, setattr, self.full, 'birth_date', NotSet)
 
         data = {'name': 'Socrates', 'age': 71, 'admin': NotSet, 'birth_date': datetime.datetime.now()}
         self.assertRaises(errors.ValidationError, ComplexResource, data)
@@ -416,10 +404,3 @@ class TestComplexResource(TestCase):
         self.assertEqual(self.full.name, co.name)
         self.assertEqual(self.full.admin, co.administrator)
         self.assertEqual(self.full.birth_date, co.birth)
-
-    def test_resource_to_object_not_mutable_field(self):
-        co = ComplexObj()
-        co.birth = datetime.datetime(1995, 1, 1)
-        self.assertRaises(errors.BadRequestError,
-                          self.full.to_obj,
-                          co, co.resource_mapping)


### PR DESCRIPTION
#### What's this PR do?
Adds the `mutable` attribute to fields. Will only allow field value to be set on creation. Raises a `ValidationError` when trying to update a field with `mutable=False`.

#### What are the relevant tickets?
[PLAT-267 - Add mutable attribute to fields](https://eventmobi.atlassian.net/browse/PLAT-267)

#### Testing:
- [x] Do you have appropriate unit test coverage?
