### PR TITLE
PLAT-361 Support sorting on None values

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name='Thorium',
-    version='0.1.43',
+    version='0.1.44',
     description='A Python framework for RESTful API interfaces in Flask',
     author='Ryan Easterbrook',
     author_email='ryan@eventmobi.com',

--- a/thorium/response.py
+++ b/thorium/response.py
@@ -79,18 +79,7 @@ class CollectionResponse(Response):
             sort_by = self.sort.split(',')
             for field in reversed(sort_by):
                 field, reverse = self._check_and_strip_first_char(field)
-                if not hasattr(self.resources[0], field):
-                    raise errors.BadRequestError(
-                        'Cannot sort by field `{}`. It does not exist in the '
-                        'resource.'.format(field)
-                    )
-                elif (isinstance(getattr(self.resources[0], field), dict) or
-                      isinstance(getattr(self.resources[0], field), list) or
-                      isinstance(getattr(self.resources[0], field), set)):
-                    raise errors.BadRequestError(
-                        'Cannot sort by field `{}`. Field type is not sortable.'
-                        .format(field)
-                    )
+                self._validate_sort_field(field)
                 not_sortable, sortable, = [], []
                 for resource in self.resources:
                     if getattr(resource, field) is None:
@@ -117,10 +106,23 @@ class CollectionResponse(Response):
             self.resources = self.resources[start:end]
 
     def _check_and_strip_first_char(self, field):
-        field = field.strip()
         reverse = field.startswith('-')
         field = field.lstrip('+-')
         return field, reverse
+
+    def _validate_sort_field(self, field):
+        if not hasattr(self.resources[0], field):
+            raise errors.BadRequestError(
+                'Cannot sort by field `{}`. It does not exist in the resource.'
+                .format(field)
+            )
+        elif (isinstance(getattr(self.resources[0], field), dict) or
+              isinstance(getattr(self.resources[0], field), list) or
+              isinstance(getattr(self.resources[0], field), set)):
+            raise errors.BadRequestError(
+                'Cannot sort by field `{}`. Field type is not sortable.'
+                .format(field)
+            )
 
     def _validate_offset_and_limit(self):
         try:

--- a/thorium/response.py
+++ b/thorium/response.py
@@ -75,15 +75,33 @@ class CollectionResponse(Response):
 
     def _sort(self):
         if self.sort:
-            reverse = self._check_and_strip_first_char()
+            self.meta['sort'] = self.sort
             sort_by = self.sort.split(',')
-            for field in sort_by:
+            for field in reversed(sort_by):
+                field, reverse = self._check_and_strip_first_char(field)
                 if not hasattr(self.resources[0], field):
                     raise errors.BadRequestError(
                         'Cannot sort by field `{}`. It does not exist in the '
                         'resource.'.format(field)
                     )
-            self.resources.sort(key=attrgetter(*sort_by), reverse=reverse)
+                elif (isinstance(getattr(self.resources[0], field), dict) or
+                      isinstance(getattr(self.resources[0], field), list) or
+                      isinstance(getattr(self.resources[0], field), set)):
+                    raise errors.BadRequestError(
+                        'Cannot sort by field `{}`. Field type is not sortable.'
+                        .format(field)
+                    )
+                not_sortable, sortable, = [], []
+                for resource in self.resources:
+                    if getattr(resource, field) is None:
+                        not_sortable.append(resource)
+                    else:
+                        sortable.append(resource)
+                sortable.sort(key=attrgetter(field), reverse=reverse)
+                if reverse:
+                    self.resources = sortable + not_sortable
+                else:
+                    self.resources = not_sortable + sortable
 
     def _paginate(self):
         if self.offset is not None and self.limit is not None:
@@ -98,11 +116,11 @@ class CollectionResponse(Response):
             end = self.offset + self.limit
             self.resources = self.resources[start:end]
 
-    def _check_and_strip_first_char(self):
-        self.meta['sort'] = self.sort
-        reverse = self.sort.startswith('-')
-        self.sort = self.sort.lstrip('+-')
-        return reverse
+    def _check_and_strip_first_char(self, field):
+        field = field.strip()
+        reverse = field.startswith('-')
+        field = field.lstrip('+-')
+        return field, reverse
 
     def _validate_offset_and_limit(self):
         try:

--- a/thorium/testsuite/test_response.py
+++ b/thorium/testsuite/test_response.py
@@ -13,6 +13,14 @@ class SimpleResource(Resource):
     name = fields.CharField()
 
 
+class ComplexResource(Resource):
+    id = fields.IntField(notnull=True)
+    name = fields.CharField(default='noname')
+    items = fields.ListField(item_type=fields.IntField())
+    hash_map = fields.DictField(notnull=True)
+    unique = fields.SetField()
+
+
 class TestResponse(TestCase):
 
     def setUp(self):
@@ -66,6 +74,16 @@ class TestCollectionResponse(TestCase):
             SimpleResource(id=4, name='b'),
             SimpleResource(id=3, name='d'),
             SimpleResource(id=5, name='d'),
+        ]
+        self.test_data_none = [
+            SimpleResource(id=1, name='a'),
+            SimpleResource(id=1, name=None),
+            SimpleResource(id=3, name='b'),
+        ]
+        self.test_data_complex = [
+            ComplexResource(id=3, items=[], hash_map={'one': 1}, unique=set()),
+            ComplexResource(id=1, items=[1], hash_map={}, unique=None),
+            ComplexResource(id=2, items=None, hash_map={}, unique={1, 2})
         ]
 
     def test_attributes(self):
@@ -128,9 +146,37 @@ class TestCollectionResponse(TestCase):
         self.assertEqual(data[3], {'id': 4, 'name': 'b'})
         self.assertEqual(data[4], {'id': 1, 'name': 'a'})
 
+    def test_get_response_data_sort_mixed(self):
+        self.response.resources = self.test_data
+        self.response.sort = '-name,+id'
+        data = self.response.get_response_data()
+        self.assertEqual(len(data), len(self.test_data))
+        self.assertEqual(data[0], {'id': 3, 'name': 'd'})
+        self.assertEqual(data[1], {'id': 5, 'name': 'd'})
+        self.assertEqual(data[2], {'id': 2, 'name': 'c'})
+        self.assertEqual(data[3], {'id': 4, 'name': 'b'})
+        self.assertEqual(data[4], {'id': 1, 'name': 'a'})
+
+    def test_get_response_data_sort_with_none(self):
+        self.response.resources = self.test_data_none
+        self.response.sort = 'name,-id'
+        data = self.response.get_response_data()
+        self.assertEqual(len(data), len(self.test_data_none))
+        self.assertEqual(data[0], {'id': 1, 'name': None})
+        self.assertEqual(data[1], {'id': 1, 'name': 'a'})
+        self.assertEqual(data[2], {'id': 3, 'name': 'b'})
+
     def test_get_response_data_sort_invalid(self):
         self.response.resources = self.test_data
         self.response.sort = '+NotAField'
+        self.assertRaises(BadRequestError, self.response.get_response_data)
+
+        self.response.resources = self.test_data_complex
+        self.response.sort = '-items'
+        self.assertRaises(BadRequestError, self.response.get_response_data)
+        self.response.sort = 'hash_map'
+        self.assertRaises(BadRequestError, self.response.get_response_data)
+        self.response.sort = 'unique'
         self.assertRaises(BadRequestError, self.response.get_response_data)
 
     def test_get_response_data_paginate(self):
@@ -143,7 +189,7 @@ class TestCollectionResponse(TestCase):
 
     def test_get_response_data_paginate_cast(self):
         self.response.resources = self.test_data
-        self.response.sort = '+id'
+        self.response.sort = 'id'
         self.response.offset = '2'
         self.response.limit = '2'
         data = self.response.get_response_data()

--- a/thorium/testsuite/test_response.py
+++ b/thorium/testsuite/test_response.py
@@ -119,7 +119,7 @@ class TestCollectionResponse(TestCase):
 
     def test_get_response_data_sort_descending_multiple(self):
         self.response.resources = self.test_data
-        self.response.sort = '-name,id'
+        self.response.sort = '-name,-id'
         data = self.response.get_response_data()
         self.assertEqual(len(data), len(self.test_data))
         self.assertEqual(data[0], {'id': 5, 'name': 'd'})

--- a/thorium/testsuite/test_thoriumflask.py
+++ b/thorium/testsuite/test_thoriumflask.py
@@ -117,13 +117,13 @@ class TestThoriumFlask(unittest.TestCase):
             })
 
     def test_get_with_sort_multiple(self):
-        rv = self.c.open('/api/event/1/people?times=5&sort=-name,id',
+        rv = self.c.open('/api/event/1/people?times=5&sort=-name,-id',
                          method='GET')
         self.assertEqual(rv.status_code, 200)
         body = json.loads(rv.data.decode())
         items = body['data']
         meta = body['meta']
-        self.assertDictEqual(meta, {'sort': '-name,id'})
+        self.assertDictEqual(meta, {'sort': '-name,-id'})
         self.assertEqual(len(items), 5)
         for x in range(5):
             self.assertDictEqual(items[x], {

--- a/thorium/testsuite/test_thoriumflask.py
+++ b/thorium/testsuite/test_thoriumflask.py
@@ -16,7 +16,7 @@ class PersonResource(Resource):
     id = fields.IntField(default=None)
     name = fields.CharField()
     birth_date = fields.DateTimeField()
-    admin = fields.BoolField()
+    admin = fields.BoolField(default=False)
 
 
 class CollectionParams(Resource):
@@ -124,6 +124,24 @@ class TestThoriumFlask(unittest.TestCase):
         items = body['data']
         meta = body['meta']
         self.assertDictEqual(meta, {'sort': '-name,-id'})
+        self.assertEqual(len(items), 5)
+        for x in range(5):
+            self.assertDictEqual(items[x], {
+                'id': 4 - x,
+                'name': 'Timmy',
+                'birth_date': '1974-03-13T00:00:00',
+                'admin': True
+            })
+
+    def test_get_with_sort_mixed(self):
+        rv = self.c.open('/api/event/1/people?times=5&sort=name,-id',
+                         method='GET')
+        self.assertEqual(rv.status_code, 200)
+        body = json.loads(rv.data.decode())
+        items = body['data']
+        print(body)
+        meta = body['meta']
+        self.assertDictEqual(meta, {'sort': 'name,-id'})
         self.assertEqual(len(items), 5)
         for x in range(5):
             self.assertDictEqual(items[x], {


### PR DESCRIPTION
#### What's this PR do?
- Pop item if the field value is None and prepend to original list after the sort
- Allow individual directional sorting of fields. Before, sorting by multiple fields would apply the direction to all fields. Now you can do `?sort=name,-id,email`

#### Testing:
- [x] Do you have appropriate unit test coverage?