### PR TITLE
Serialize bytes objects assuming UTF-8 text.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name='Thorium',
-    version='0.1.44',
+    version='0.1.45',
     description='A Python framework for RESTful API interfaces in Flask',
     author='Ryan Easterbrook',
     author_email='ryan@eventmobi.com',

--- a/thorium/serializer.py
+++ b/thorium/serializer.py
@@ -41,8 +41,10 @@ class JsonSerializer(SerializerBase):
 def handler(obj):
     if hasattr(obj, 'isoformat'):
         return obj.isoformat()
-    if isinstance(obj, uuid.UUID):
+    elif isinstance(obj, uuid.UUID):
         return str(obj)
+    elif isinstance(obj, bytes):
+        return obj.decode('utf-8')
     else:
         err_msg = 'Object of type %s with value of %s is not JSON serializable'
         raise TypeError(err_msg % (type(obj), repr(obj)))


### PR DESCRIPTION
Sometimes we're serializing stuff pretty much directly from boto and it always comes back as `bytes`. This is to save us from having to handle that every single time.