### PR TITLE
DS-62 Adds more flexible parsing for isoformated datetimes 

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,13 +2,13 @@ from setuptools import setup
 
 setup(
     name='Thorium',
-    version='0.1.49',
+    version='0.1.50',
     description='A Python framework for RESTful API interfaces in Flask',
     author='Ryan Easterbrook',
     author_email='ryan@eventmobi.com',
     url='https://github.com/EventMobi/thorium',
     packages=['thorium', 'thorium.ext'],
-    install_requires=['Flask==0.10.1', 'jsonschema==2.4.0'],
+    install_requires=['Flask==0.10.1', 'jsonschema==2.4.0', 'arrow==0.5.4'],
     license='BSD',
     classifiers=[
         'Framework :: Flask',

--- a/thorium/testsuite/test_fields.py
+++ b/thorium/testsuite/test_fields.py
@@ -183,6 +183,23 @@ class TestDateTimeValidator(TestCase):
         result = self.validator.validate(dt)
         self.assertEqual(dt, result)
 
+    def test_isoformated_date_to_datetime(self):
+        dt = datetime.datetime(2015, 3, 2)
+        result = self.validator.validate('2015-03-02', cast=True)
+        self.assertEqual(dt, result)
+
+    def test_isoformated_datetime_to_datetime(self):
+        dt = datetime.datetime(2015, 3, 2, hour=14, minute=41, second=53)
+        result = self.validator.validate('2015-03-02T14:41:53', cast=True)
+        self.assertEqual(dt, result)
+
+    def test_isoformated_datetime_with_microseconds_to_datetime(self):
+        dt = datetime.datetime(2015, 3, 2, hour=14, minute=41, second=53,
+                               microsecond=834910)
+        result = self.validator.validate('2015-03-02T14:41:53.834910',
+                                         cast=True)
+        self.assertEqual(dt, result)
+
     def test_str_invalid(self):
         self.assertRaises(errors.ValidationError, self.validator.validate,
                           'abc')
@@ -193,6 +210,10 @@ class TestDateTimeValidator(TestCase):
 
     def test_int_invalid(self):
         self.assertRaises(errors.ValidationError, self.validator.validate, 1)
+
+    def test_invalid_isoformated_datetime(self):
+        self.assertRaises(errors.ValidationError, self.validator.validate,
+                          '2015-03-02Z14:41:53.834910')
 
 
 class TestUUIDValidator(TestCase):

--- a/thorium/testsuite/test_fields.py
+++ b/thorium/testsuite/test_fields.py
@@ -213,7 +213,7 @@ class TestDateTimeValidator(TestCase):
 
     def test_invalid_isoformated_datetime(self):
         self.assertRaises(errors.ValidationError, self.validator.validate,
-                          '2015-03-02Z14:41:53.834910')
+                          'asdf')
 
 
 class TestUUIDValidator(TestCase):

--- a/thorium/validators.py
+++ b/thorium/validators.py
@@ -4,7 +4,9 @@ import numbers
 import datetime
 import uuid
 import json
+
 import jsonschema
+import arrow
 
 from . import errors, NotSet
 
@@ -139,7 +141,12 @@ class DateTimeValidator(FieldValidator):
 
     def attempt_cast(self, value):
         if isinstance(value, str):
-            return datetime.datetime.strptime(value, "%Y-%m-%dT%H:%M:%S")
+            try:
+                return arrow.get(value).datetime.replace(tzinfo=None)
+            except arrow.parser.ParserError as e:
+                raise errors.ValidationError(
+                    'Field {0}: '.format(self._field) + str(e)
+                )
         elif isinstance(value, numbers.Number) and not isinstance(value, bool):
             return datetime.datetime.utcfromtimestamp(value)
         else:

--- a/thorium/validators.py
+++ b/thorium/validators.py
@@ -145,7 +145,7 @@ class DateTimeValidator(FieldValidator):
                 return arrow.get(value).datetime.replace(tzinfo=None)
             except arrow.parser.ParserError as e:
                 raise errors.ValidationError(
-                    'Field {0}: '.format(self._field) + str(e)
+                    'Field {0}: {1}'.format(self._field, e)
                 )
         elif isinstance(value, numbers.Number) and not isinstance(value, bool):
             return datetime.datetime.utcfromtimestamp(value)


### PR DESCRIPTION
Thorium's DateTime validator, when casting, will now accept a wider range of isoformated datetime strings, including with and without the microsecond component. 