### PR TITLE
Add received type to string validation error.

### DIFF
--- a/thorium/validators.py
+++ b/thorium/validators.py
@@ -80,7 +80,8 @@ class CharValidator(FieldValidator):
         return str(value)
 
     def raise_validation_error(self, value):
-        raise errors.ValidationError('{0} expects a string, got {1}'.format(self._field, value))
+        err_msg = '{} expects a string, got {}:{}'
+        raise errors.ValidationError(err_msg.format(self._field, type(value), value))
 
     def additional_validation(self, value):
         if self._field.flags['max_length'] and len(value) > self._field.flags['max_length']:


### PR DESCRIPTION
This is to reduce the ambiguity of error messages like:

```
'Length field expected a string, got 11 instead'
```
