### PR TITLE
RouteManager refactor

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name='Thorium',
-    version='0.1.53',
+    version='0.2.0',
     description='A Python framework for RESTful API interfaces in Flask',
     author='Ryan Easterbrook',
     author_email='ryan@eventmobi.com',

--- a/thorium/routing.py
+++ b/thorium/routing.py
@@ -50,35 +50,33 @@ class RouteManager(object):
 
         return self._routes
 
-    def register_endpoint(self, endpoint_cls):
-        if not hasattr(endpoint_cls, 'routes') or not isinstance(endpoint_cls.routes, list):
-            raise Exception('Endpoint {0} expects attribute routes to be a list of Route objects.'
-                            .format(endpoint_cls.__name__))
+    def collection(self, path, methods, parameters_cls=None):
+        def wrapped(cls):
+            route = build_route(dispatcher.CollectionDispatcher,
+                                cls,
+                                parameters_cls,
+                                path,
+                                methods)
+            self._routes.append(route)
+            if hasattr(cls, 'routes'):
+                cls.routes.append(route)
+            else:
+                cls.routes = [route]
+            return cls
+        return wrapped
 
-        for route in endpoint_cls.routes:
-            self.add_route(route)
-
-
-def collection(path, methods, parameters_cls=None):
-    def wrapped(cls):
-        route = build_route(dispatcher.CollectionDispatcher, cls, parameters_cls, path, methods)
-        if hasattr(cls, 'routes'):
-            cls.routes.append(route)
-        else:
-            cls.routes = [route]
-        return cls
-    return wrapped
-
-
-def detail(path, methods, parameters_cls=None):
-    def wrapped(cls):
-        route = build_route(dispatcher.DetailDispatcher, cls, parameters_cls, path, methods)
-        if hasattr(cls, 'routes'):
-            cls.routes.append(route)
-        else:
-            cls.routes = [route]
-        return cls
-    return wrapped
+    def detail(self, path, methods, parameters_cls=None):
+        def wrapped(cls):
+            route = build_route(dispatcher.DetailDispatcher,
+                                cls,
+                                parameters_cls, path, methods)
+            self._routes.append(route)
+            if hasattr(cls, 'routes'):
+                cls.routes.append(route)
+            else:
+                cls.routes = [route]
+            return cls
+        return wrapped
 
 
 def build_route(dispatcher_cls, endpoint_cls, parameters_cls, path, methods):

--- a/thorium/testsuite/test_routing.py
+++ b/thorium/testsuite/test_routing.py
@@ -1,6 +1,6 @@
 import unittest
 from unittest import mock
-from thorium import Endpoint, Resource, Route, RouteManager, dispatcher
+from thorium import Route, RouteManager
 
 
 class TestRouteManager(unittest.TestCase):
@@ -14,28 +14,14 @@ class TestRouteManager(unittest.TestCase):
     def test_add_route(self):
         route = mock.MagicMock(spec=Route)
         self.route_manager.add_route(route)
-        self.assertIn(route, self.route_manager._routes, 'new route should be in _routes')
+        self.assertIn(route, self.route_manager._routes,
+                      'new route should be in _routes')
 
     def test_get_all_routes(self):
         route1 = mock.MagicMock(spec=Route)
         route2 = mock.MagicMock(spec=Route)
         self.route_manager.add_route(route1)
         self.route_manager.add_route(route2)
-        routes = self.route_manager.get_all_routes()
-        self.assertIn(route1, routes)
-        self.assertIn(route2, routes)
-
-    def test_register_resource(self):
-        resource = mock.MagicMock()
-        resource.__name__ = 'res'
-        endpoint = mock.MagicMock()
-        endpoint.__name__ = 'ep'
-        route1 = mock.MagicMock(spec=Route)
-        route2 = mock.MagicMock(spec=Route)
-        endpoint.routes = [route1, route2]
-        self.route_manager.register_endpoint(endpoint)
-
-        #newly created routes should be internally tracked by the route_manager
         routes = self.route_manager.get_all_routes()
         self.assertIn(route1, routes)
         self.assertIn(route2, routes)

--- a/thorium/testsuite/test_thoriumflask.py
+++ b/thorium/testsuite/test_thoriumflask.py
@@ -8,8 +8,15 @@ from collections import OrderedDict
 
 from flask import Flask
 
-from thorium import (ThoriumFlask, RouteManager, Resource, fields, Endpoint,
-                     routing)
+from thorium import (
+    ThoriumFlask,
+    RouteManager,
+    Resource,
+    fields,
+    Endpoint,
+)
+
+routing = RouteManager()
 
 
 class PersonResource(Resource):
@@ -60,12 +67,10 @@ class PersonEndpoint(Endpoint):
 class TestThoriumFlask(unittest.TestCase):
 
     def setUp(self):
-        route_manager = RouteManager()
-        route_manager.register_endpoint(PersonEndpoint)
         self.flask_app = Flask(__name__)
         ThoriumFlask(
             settings={},
-            route_manager=route_manager,
+            route_manager=routing,
             flask_app=self.flask_app
         )
         self.c = self.flask_app.test_client()
@@ -268,12 +273,10 @@ class TestThoriumFlask(unittest.TestCase):
 class TestResourceSpeed(unittest.TestCase):
 
     def setUp(self):
-        route_manager = RouteManager()
-        route_manager.register_endpoint(PersonEndpoint)
         self.flask_app = Flask(__name__)
         ThoriumFlask(
             settings={},
-            route_manager=route_manager,
+            route_manager=routing,
             flask_app=self.flask_app
         )
         self.c = self.flask_app.test_client()


### PR DESCRIPTION
`thorium.routing.detail` and `thorium.routing.collection` are now
methods of the `thorium.routing.RouteManager` class and register to it
when the decorator is evaluated.