### PR TITLE
Adds authorization to CORS access-control-allow-headers

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name='Thorium',
-    version='0.2.12',
+    version='0.2.13',
     description='A Python framework for RESTful API interfaces in Flask',
     author='Ryan Easterbrook',
     author_email='ryan@eventmobi.com',

--- a/thorium/crossdomain_decorator.py
+++ b/thorium/crossdomain_decorator.py
@@ -35,7 +35,7 @@ def crossdomain(origin=None, methods=None, headers=None,
 
             h['Access-Control-Allow-Origin'] = request.headers['origin'] if 'origin' in request.headers else '*'
             h['Access-Control-Max-Age'] = str(max_age)
-            h['Access-Control-Allow-Headers'] = 'accept, origin, content-type, X-EM-Token'
+            h['Access-Control-Allow-Headers'] = 'accept, origin, content-type, X-EM-Token, authorization'
             h['Access-Control-Expose-Headers'] = 'Location, X-EM-Token'
             h['Access-Control-Allow-Credentials'] = 'true'
             if headers is not None:


### PR DESCRIPTION
Proposing adding `authorization` to the CORS `Access-Control-Allow-Headers` list to allow Browsers to submit a Bearer token. 

This might not seem like a great idea and I'm not saying we should encourage the use of hardcoding a bearer token in a web app, but it's the only option until Flux allows and facilitates logins.